### PR TITLE
Better support for nested namespaces

### DIFF
--- a/lib/cancan_namespace/controller_resource.rb
+++ b/lib/cancan_namespace/controller_resource.rb
@@ -28,7 +28,7 @@ module CanCanNamespace
         def module_from_controller
           modules = @params[:controller].sub("Controller", "").underscore.split('/')
           if modules.size > 1
-            modules.first.singularize
+            modules[0..-2].map(&:singularize).join('__')
           else
             return nil
           end


### PR DESCRIPTION
Since this repo has not been touched for years I do not really expect any response here, but I wanted to give it a try ;)

The current implementation only uses the first module of the chain to determine the context name to automatically use for `authorize_resource`. This does not allow to distinguish between several nested namespaces without specifying a custom context name everywhere. This little change makes it possible.

I used the double underscore as a delimiter to avoid ambiguous names when a controller has a prefix in its name equal to the namespace of another controller. I do not insist on this choice if you have another suggestion.

While the new implementation will not affect controllers with only one parent namespace, it _may_ break existing code when people relied on the previous behavior.
