### PR TITLE
Remove duplicate default value

### DIFF
--- a/lib/cancan_namespace/ability.rb
+++ b/lib/cancan_namespace/ability.rb
@@ -45,7 +45,6 @@ module CanCanNamespace
       # Returns an array of Rule instances which match the action and subject
       # This does not take into consideration any hash conditions or block statements
       def relevant_rules(action, subject, context = nil)
-        context ||= @context
         rules.reverse.select do |rule|
           rule.expanded_actions = expand_actions(rule.actions)
           rule.relevant? action, subject, context


### PR DESCRIPTION
If you are in a namespaced controller it is currently not possible to make a `can?`-Lookup for the `nil`-Context, because a `nil` value would be overridden by the line I removed in this pull request. Since the `@context` value is already used in the `can?` method (line 24), this default override is superfluous anyway.
