### PR TITLE
Enable automatic loading of collections with respect of context

### DIFF
--- a/lib/cancan_namespace.rb
+++ b/lib/cancan_namespace.rb
@@ -2,4 +2,7 @@ require 'cancan'
 require 'cancan_namespace/ability'
 require 'cancan_namespace/rule'
 require 'cancan_namespace/controller_resource'
+require 'cancan_namespace/model_additions'
 require 'cancan_namespace/version'
+
+require 'cancan_namespace/model_adapters/active_record_adapter' if defined? ActiveRecord

--- a/lib/cancan_namespace/controller_resource.rb
+++ b/lib/cancan_namespace/controller_resource.rb
@@ -11,6 +11,8 @@ module CanCanNamespace
       def self.extended(base)
         base.class_eval do
           alias_method :authorize_resource, :authorize_resource_with_context
+          alias_method :load_collection?, :load_collection_with_context?
+          alias_method :load_collection, :load_collection_with_context
         end
       end
     end
@@ -21,6 +23,16 @@ module CanCanNamespace
           options = { :context => (@options[:context] || module_from_controller) }
           @controller.authorize!(authorization_action, resource_instance || resource_class_with_parent, options)
         end
+      end
+
+      protected
+
+      def load_collection_with_context?
+        resource_base.respond_to?(:accessible_by) && !current_ability.has_block?(authorization_action, resource_class, @options[:context] || module_from_controller)
+      end
+
+      def load_collection_with_context
+        resource_base.accessible_by(current_ability, authorization_action, @options[:context] || module_from_controller)
       end
       
       private

--- a/lib/cancan_namespace/model_adapters/active_record_adapter.rb
+++ b/lib/cancan_namespace/model_adapters/active_record_adapter.rb
@@ -1,0 +1,3 @@
+ActiveRecord::Base.class_eval do
+  include CanCanNamespace::ModelAdditions
+end

--- a/lib/cancan_namespace/model_additions.rb
+++ b/lib/cancan_namespace/model_additions.rb
@@ -1,0 +1,13 @@
+module CanCanNamespace
+  module ModelAdditions
+    module ClassMethods
+      def accessible_by(ability, action = :index, context = nil)
+        ability.model_adapter(self, action, context).database_records
+      end
+    end
+
+    def self.included(base)
+      base.extend ClassMethods
+    end
+  end
+end


### PR DESCRIPTION
I noticed the feature to automatically load collections by building a scope with the conditions of a rule was not enriched by the context functionality yet. Since I want to use that feature, I added context support for it.

I did not add the model adapters other than for ActiveRecord because I don't use them and therefore cannot easily test their behavior.
