### PR TITLE
Infer context from controller name everywhere

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -48,21 +48,21 @@ Set context for controller directly:
 
 === View
 
-  If no extra context argument is given, it defaults to the context the current controller is in
+If no extra context argument is given, it defaults to the context the current controller is in
 
   # app/views/posts/show.html.erb
   <% if can? :edit, post %>
     <%= link_to 'Edit', edit_post_path(post) %>
   <% end %>
 
-  When you want to check an ability for another context, specify it manually
+When you want to check an ability for another context, specify it manually
 
   # app/views/posts/show.html.erb
   <% if can? :edit, post, :context => :manage %>
     <%= link_to 'Edit (admin)', edit_manage_post_path(post) %>
   <% end %>
 
-  When the current controller is in a namespace and you want to check an ability for the `nil` context, meaning a controller without namespace, you need to specify `context => nil`
+When the current controller is in a namespace and you want to check an ability for the `nil` context, meaning a controller without namespace, you need to specify `context => nil`
 
   # app/views/manage/posts/show.html.erb
   <% if can? :edit, post, :context => nil %>

--- a/README.rdoc
+++ b/README.rdoc
@@ -11,8 +11,7 @@ Namespace for cancan gem.
   class Ability
     include CanCanNamespace::Ability
 
-    def initialize(user, context = nil)
-      @context = context
+    def initialize(user)
       
       ...
       
@@ -26,15 +25,7 @@ Namespace for cancan gem.
 
 === Controller
 
-  Manage::BaseController < ApplicationController
-    protected
-    
-      def current_ability
-        @current_ability ||= ::Ability.new(current_user, :manage)
-      end
-  end
-
-In this case context extracted from controller name (:manage):
+Context is extracted from controller name (:manage):
 
   class Manage::PostsController < Manage::BaseController
     before_filter :find_post, :only => [:edit, :update, :destroy]
@@ -57,12 +48,25 @@ Set context for controller directly:
 
 === View
 
+  If no extra context argument is given, it defaults to the context the current controller is in
+
+  # app/views/posts/show.html.erb
   <% if can? :edit, post %>
     <%= link_to 'Edit', edit_post_path(post) %>
   <% end %>
 
+  When you want to check an ability for another context, specify it manually
+
+  # app/views/posts/show.html.erb
   <% if can? :edit, post, :context => :manage %>
     <%= link_to 'Edit (admin)', edit_manage_post_path(post) %>
+  <% end %>
+
+  When the current controller is in a namespace and you want to check an ability for the `nil` context, meaning a controller without namespace, you need to specify `context => nil`
+
+  # app/views/manage/posts/show.html.erb
+  <% if can? :edit, post, :context => nil %>
+    <%= link_to 'Edit', edit_post_path(post) %>
   <% end %>
 
 Copyright (c) 2011 Aimbulance, released under the MIT license

--- a/README.rdoc
+++ b/README.rdoc
@@ -48,9 +48,10 @@ Set context for controller directly:
 
 === View
 
-If no extra context argument is given, it defaults to the context the current controller is in
+If no extra context argument is given, it defaults to the namespace where the current controller lives
 
   # app/views/posts/show.html.erb
+  # controller has no namespace -> context = nil
   <% if can? :edit, post %>
     <%= link_to 'Edit', edit_post_path(post) %>
   <% end %>
@@ -65,6 +66,7 @@ When you want to check an ability for another context, specify it manually
 When the current controller is in a namespace and you want to check an ability for the `nil` context, meaning a controller without namespace, you need to specify `context => nil`
 
   # app/views/manage/posts/show.html.erb
+  # controller has namespace "manage" -> context is manually overridden to `nil`
   <% if can? :edit, post, :context => nil %>
     <%= link_to 'Edit', edit_post_path(post) %>
   <% end %>

--- a/lib/cancan_namespace.rb
+++ b/lib/cancan_namespace.rb
@@ -2,6 +2,7 @@ require 'cancan'
 require 'cancan_namespace/ability'
 require 'cancan_namespace/rule'
 require 'cancan_namespace/controller_resource'
+require 'cancan_namespace/controller_additions'
 require 'cancan_namespace/model_additions'
 require 'cancan_namespace/version'
 

--- a/lib/cancan_namespace/ability.rb
+++ b/lib/cancan_namespace/ability.rb
@@ -18,13 +18,8 @@ module CanCanNamespace
   module Ability
     include CanCan::Ability
     
-    attr_accessor :context
-
     def can?(action, subject, *extra_args)
-      context = @context
-      if extra_args.last.kind_of?(Hash) && extra_args.last.has_key?(:context)
-        context = extra_args.pop[:context]
-      end
+      context = extra_args.pop[:context] if extra_args.last.kind_of?(Hash) && extra_args.last.key?(:context)
       
       match = relevant_rules_for_match(action, subject, context).detect do |rule|
         rule.matches_conditions?(action, subject, extra_args)

--- a/lib/cancan_namespace/controller_additions.rb
+++ b/lib/cancan_namespace/controller_additions.rb
@@ -1,0 +1,34 @@
+module CanCanNamespace
+  module ControllerAdditions
+    def can?(*args)
+      super(*inject_context(args))
+    end
+
+    def cannot?(*args)
+      super(*inject_context(args))
+    end
+
+    def get_context
+      modules = params[:controller].sub("Controller", "").underscore.split('/')
+      if modules.size > 1
+        modules[0..-2].map(&:singularize).join('__')
+      else
+        return nil
+      end
+    end
+
+    private
+
+    def inject_context(args)
+      args[2] ||= {}
+      args[2].reverse_merge!(context: get_context) if args[2].kind_of?(Hash)
+      args
+    end
+  end
+end
+
+if defined? ActionController::Base
+  ActionController::Base.class_eval do
+    include CanCanNamespace::ControllerAdditions
+  end
+end

--- a/lib/cancan_namespace/controller_resource.rb
+++ b/lib/cancan_namespace/controller_resource.rb
@@ -20,7 +20,7 @@ module CanCanNamespace
     module InstanceMethods
       def authorize_resource_with_context
         unless skip?(:authorize)
-          options = { :context => (@options[:context] || module_from_controller) }
+          options = { :context => (@options[:context] || @controller.get_context) }
           @controller.authorize!(authorization_action, resource_instance || resource_class_with_parent, options)
         end
       end
@@ -28,23 +28,12 @@ module CanCanNamespace
       protected
 
       def load_collection_with_context?
-        resource_base.respond_to?(:accessible_by) && !current_ability.has_block?(authorization_action, resource_class, @options[:context] || module_from_controller)
+        resource_base.respond_to?(:accessible_by) && !current_ability.has_block?(authorization_action, resource_class, @options[:context] || @controller.get_context)
       end
 
       def load_collection_with_context
-        resource_base.accessible_by(current_ability, authorization_action, @options[:context] || module_from_controller)
+        resource_base.accessible_by(current_ability, authorization_action, @options[:context] || @controller.get_context)
       end
-      
-      private
-      
-        def module_from_controller
-          modules = @params[:controller].sub("Controller", "").underscore.split('/')
-          if modules.size > 1
-            modules[0..-2].map(&:singularize).join('__')
-          else
-            return nil
-          end
-        end
     end
   end
 end


### PR DESCRIPTION
The extra `@context` parameter for the Ability model has confused me for a while now. In most occurrences of the context functionality, it is inferred from the controller name - but not for the `can?`/`cannot?` methods in the views. This pull request removes the `@context` variable entirely and makes all relevant methods extract the context from the controller namespace by default. This way, you don't have to specify the context in an extra `current_ability` override for every controller that has a namespace. I also updated the readme file.
