### PR TITLE
Enable record attribute initiation with rules from context

### DIFF
--- a/lib/cancan_namespace/ability.rb
+++ b/lib/cancan_namespace/ability.rb
@@ -43,6 +43,14 @@ module CanCanNamespace
     def has_block?(action, subject, context = nil)
       relevant_rules(action, subject, context).any?(&:only_block?)
     end
+
+    def attributes_for(action, subject, context = nil)
+      attributes = {}
+      relevant_rules(action, subject, context).each do |rule|
+        attributes.merge!(rule.attributes_from_conditions) if rule.base_behavior
+      end
+      attributes
+    end
     
     private
     

--- a/lib/cancan_namespace/controller_resource.rb
+++ b/lib/cancan_namespace/controller_resource.rb
@@ -13,6 +13,7 @@ module CanCanNamespace
           alias_method :authorize_resource, :authorize_resource_with_context
           alias_method :load_collection?, :load_collection_with_context?
           alias_method :load_collection, :load_collection_with_context
+          alias_method :initial_attributes, :initial_attributes_with_context
         end
       end
     end
@@ -33,6 +34,12 @@ module CanCanNamespace
 
       def load_collection_with_context
         resource_base.accessible_by(current_ability, authorization_action, @options[:context] || @controller.get_context)
+      end
+
+      def initial_attributes_with_context
+        current_ability.attributes_for(@params[:action].to_sym, resource_class, @options[:context] || @controller.get_context).delete_if do |key, value|
+          resource_params && resource_params.include?(key)
+        end
       end
     end
   end


### PR DESCRIPTION
Until now, rules with context would be ignored when building records with inital attributes.
